### PR TITLE
docs: note flat-config migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,11 @@ export default [
   },
 ];
 ```
+
+## Migration
+
+The flat-config port changed the exported preset names.
+
+- `configs/node.js` was replaced by `configs/js.js`
+- `configs/typescript.js` was replaced by `configs/ts.js`
+- the package default export now matches `configs/js.js`


### PR DESCRIPTION
## Summary
- document the preset renames introduced by the flat-config port
- note that the package default export now matches `configs/js.js`
- use this PR to trigger the correct semantic release for the already-merged breaking change

## Test Plan
- [x] `node -e "import('./index.js').then((m) => console.log(Array.isArray(m.default), m.default.length))"`
- [x] `node -e "import('./eslint.config.js').then((m) => console.log(Array.isArray(m.default), m.default.length))"`
- [x] `npx eslint . --no-error-on-unmatched-pattern`
