### PR TITLE
fix: restore legacy config entrypoints

### DIFF
--- a/configs/node.js
+++ b/configs/node.js
@@ -1,0 +1,3 @@
+import js from "./js.js";
+
+export default js;

--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -1,0 +1,3 @@
+import ts from "./ts.js";
+
+export default ts;


### PR DESCRIPTION
## Summary
- restore `configs/node.js` as an alias to `configs/js.js`
- restore `configs/typescript.js` as an alias to `configs/ts.js`
- reduce breakage for consumers while still preserving the new flat-config layout

## Test Plan
- [x] `node -e "import('./configs/node.js').then((m) => console.log(Array.isArray(m.default), m.default.length))"`
- [x] `node -e "import('./configs/typescript.js').then((m) => console.log(Array.isArray(m.default), m.default.length))"`
- [x] `npx eslint . --no-error-on-unmatched-pattern`
